### PR TITLE
support for flag in cookies & toValueString for multiple cookies

### DIFF
--- a/cookiejar.js
+++ b/cookiejar.js
@@ -68,7 +68,7 @@ Cookie.prototype.parse = function parse(str) {
     	this.value = value;
     
     	for(var i=1;i<parts.length;i++) {
-    		pair=parts[i].match(/([^=]+)=((?:.|\n)*)/)
+    		pair=parts[i].match(/([^=]+)(?:=((?:.|\n)*))?/)
     		, key=pair[1].trim().toLowerCase()
     		, value=pair[2];
     		switch(key) {

--- a/cookiejar.js
+++ b/cookiejar.js
@@ -197,6 +197,7 @@ exports.CookieJar=CookieJar=function CookieJar() {
     			}
     		}
     		matches.toString=function toString(){return matches.join(":");}
+            matches.toValueString=function() {return matches.map(function(c){return c.toValueString();}).join(';');}
     		return matches;
     	}
     

--- a/tests/test.js
+++ b/tests/test.js
@@ -23,3 +23,6 @@ console.log(
 	|| "Delete cookie fail"+cookies.length+"\n"+cookies.toString());
     
 console.log(String(test_jar.getCookies(CookieAccessInfo("test.com","/"))))
+
+cookie=Cookie("a=1;domain=test.com;path=/;HttpOnly");
+console.log(cookie.noscript || "HttpOnly flag parsing failed\n"+cookie.toString());

--- a/tests/test.js
+++ b/tests/test.js
@@ -12,6 +12,9 @@ var cookies=test_jar.getCookies(CookieAccessInfo("test.com","/"))
 console.log(
 	cookies.length==2
 	|| "Expires on setCookies fail"+cookies.length+"\n"+cookies.toString());
+console.log(
+    cookies.toValueString() == 'a=1;b=2'
+    || "Cannot get value string of multiple cookies");
 cookies=test_jar.getCookies(CookieAccessInfo("www.test.com","/"))
 console.log(
 	cookies.length==1


### PR DESCRIPTION
- flag in cookie strings have no `=` sign and no value. Example : `a=1;domain=test.com;path=/;HttpOnly`

modified the regexp for key value part, the equal sign is now optional.
- convenience function `toValueString` on the result of `getCookies`.

useful to generate `Cookie` header value in an HTTP client from a set matching cookies.
