### PR TITLE
Added fix to ensure that the request_domain and request_path get passed to the Cookie constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/cookiejar.js
+++ b/cookiejar.js
@@ -33,7 +33,7 @@
             }
             return this;
         }
-        return new Cookie(cookiestr);
+        return new Cookie(cookiestr, request_domain, request_path);
     }
     exports.Cookie = Cookie;
 
@@ -248,7 +248,9 @@
         var successful = [],
             i,
             cookie;
-        cookies = cookies.map(Cookie);
+        cookies = cookies.map(function(item){
+            return Cookie(item, request_domain, request_path);
+        });
         for (i = 0; i < cookies.length; i += 1) {
             cookie = cookies[i];
             if (this.setCookie(cookie, request_domain, request_path)) {

--- a/cookiejar.js
+++ b/cookiejar.js
@@ -249,7 +249,7 @@
             i,
             cookie;
         cookies = cookies.map(function(item){
-            return Cookie(item, request_domain, request_path);
+            return new Cookie(item, request_domain, request_path);
         });
         for (i = 0; i < cookies.length; i += 1) {
             cookie = cookies[i];

--- a/package.json
+++ b/package.json
@@ -12,10 +12,13 @@
   },
   "scripts": {
     "prepublish": "jshint cookiejar.js && git tag $npm_package_version && git push origin master && git push origin --tags",
-    "test": "tests/test.js"
+    "test": "node tests/test.js"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/bmeck/node-cookiejar.git"
+  },
+  "dependencies": {
+    "jshint": "^2.8.0"
   }
 }


### PR DESCRIPTION
I noticed that when using the setCookies method and passing it an array of cookie headers, it wasn't saving the request_domain and request_path parameters. I modified calls to the Cookie() constructor so that they will pass those two variables.