### PR TITLE
Fix explicit path, again

### DIFF
--- a/cookiejar.js
+++ b/cookiejar.js
@@ -133,7 +133,7 @@
         if (this.path && access_info.path.indexOf(this.path) !== 0) {
             return false;
         }
-        if (this.explicit_path && this.path !== access_info.path) {
+        if (this.explicit_path && access_info.path.indexOf( this.path ) !== 0) {
            return false;
         }
         var access_domain = access_info.domain && access_info.domain.replace(/^[\.]/,'');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookiejar",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": {
     "name": "bradleymeck"
   },


### PR DESCRIPTION
Explicit path needs to be tested as being the root of the path, not the entire path. That is, if a cookie has path set to '/foo', then the cookie should still be sent with '/foo/bar', but not with '/yak'.
