### PR TITLE
jshint is a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "type": "git",
     "url": "https://github.com/bmeck/node-cookiejar.git"
   },
-  "dependencies": {
+  "devDependencies": {
     "jshint": "^2.8.0"
   }
 }


### PR DESCRIPTION
This avoids needless installation of jshint for production users of cookiejar