### PR TITLE
Add a missing space to the strings produced for `cookie:`

### DIFF
--- a/cookiejar.js
+++ b/cookiejar.js
@@ -243,7 +243,7 @@
                 matches.toValueString = function toValueString() {
                     return matches.map(function (c) {
                         return c.toValueString();
-                    }).join(';');
+                    }).join('; ');
                 };
                 return matches;
             };

--- a/tests/test.js
+++ b/tests/test.js
@@ -30,7 +30,7 @@ test_jar.setCookies(
  +":c=3;domain=test.com;path=/;expires=January 1, 1970");
 var cookies=test_jar.getCookies(CookieAccessInfo("test.com","/"))
 assert.equal(cookies.length, 2, "Expires on setCookies fail\n" + cookies.toString());
-assert.equal(cookies.toValueString(), 'a=1;b=2', "Cannot get value string of multiple cookies");
+assert.equal(cookies.toValueString(), 'a=1; b=2', "Cannot get value string of multiple cookies");
 
 cookies=test_jar.getCookies(CookieAccessInfo("www.test.com","/"))
 assert.equal(cookies.length, 2, "Wildcard domain fail\n" + cookies.toString());


### PR DESCRIPTION
As far as I understand, the `toValueString` method of a list of cookies returned by `getCookies` produces a string that can be used as a value of the `Cookies` HTTP header.

If so, there is a bug. According to [the standard](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie), the cookies must be separated by `; ` (a semicolon _and a space_). Browsers follow this standard both in the HTTP header and in `document.cookie`. Meanwhile `node-cookiejar` separates the cookies by `;` (only a semicolon).

This is a problem because I use `node-cookiejar` as a dependency of [superagent](https://github.com/visionmedia/superagent), and when I request websites, they parse cookies incorrectly because of the missing space.

This PR adds the missing space. Could you please publish the change to NPM?