### PR TITLE
fix: add a guard against maliciously-sized cookies

### DIFF
--- a/cookiejar.js
+++ b/cookiejar.js
@@ -64,8 +64,8 @@
 
     var cookie_str_splitter = /[:](?=\s*[a-zA-Z0-9_\-]+\s*[=])/g;
     Cookie.prototype.parse = function parse(str, request_domain, request_path) {
-        if ( str.length > 4096 ) {
-            console.warn("Cookie too long for parsing (>4096 characters)");
+        if ( str.length > 32768 ) {
+            console.warn("Cookie too long for parsing (>32768 characters)");
             return;
         }
 

--- a/cookiejar.js
+++ b/cookiejar.js
@@ -64,6 +64,11 @@
 
     var cookie_str_splitter = /[:](?=\s*[a-zA-Z0-9_\-]+\s*[=])/g;
     Cookie.prototype.parse = function parse(str, request_domain, request_path) {
+        if ( str.length > 4096 ) {
+            console.warn("Cookie too long for parsing (>4096 characters)");
+            return;
+        }
+
         if (this instanceof Cookie) {
             var parts = str.split(";").filter(function (value) {
                     return !!value;

--- a/tests/test.js
+++ b/tests/test.js
@@ -68,7 +68,7 @@ assert.equal(cookie.path, "/");
 assert.deepEqual(cookie, new Cookie("a=1;domain=.test.com;path=/"));
 
 // ensure cookies that are too long are not parsed to avoid any issues with DoS inputs
-var too_long_cookie = new Cookie( "foo=" + "blah".repeat( 2000 ) );
+var too_long_cookie = new Cookie( "foo=" + "blah".repeat( 10000 ) );
 assert.equal(too_long_cookie, undefined);
 
 // Test request_path and request_domain

--- a/tests/test.js
+++ b/tests/test.js
@@ -67,6 +67,10 @@ assert.equal(cookie.domain, ".test.com");
 assert.equal(cookie.path, "/");
 assert.deepEqual(cookie, new Cookie("a=1;domain=.test.com;path=/"));
 
+// ensure cookies that are too long are not parsed to avoid any issues with DoS inputs
+var too_long_cookie = new Cookie( "foo=" + "blah".repeat( 2000 ) );
+assert.equal(too_long_cookie, undefined);
+
 // Test request_path and request_domain
 test_jar2.setCookie(new Cookie("sub=4;path=/", "test.com"));
 var cookie = test_jar2.getCookie("sub", CookieAccessInfo("sub.test.com", "/"));


### PR DESCRIPTION
This adds a guard to limit cookie strings we will attempt to parse to 32768 characters. I believe this is in compliance with the RFC:

> Limits
> 
> Practical user agent implementations have limits on the number and size of cookies that they can store.  General-use user agents SHOULD provide each of the following minimum capabilities:
> 
> o  At least 4096 bytes per cookie (as measured by the sum of the length of the cookie's name, value, and attributes).

